### PR TITLE
fix <section id=articles> being closed after first post

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -63,8 +63,8 @@
           </div>
         </article>
         {% endif %}
-      </section>
       {% endfor %}
+      </section>
       <!--  -->
       {% include footer.html %}
     </main>


### PR DESCRIPTION
Turns out that {% endfor %} should be moved, otherwise </section> will be written after the first post

that causes page to render without spacing between the other posts

outcome before the change:
![image](https://github.com/user-attachments/assets/e870c42f-6ccd-4871-b66e-62ffbb175189)

outcome after the change:
![image](https://github.com/user-attachments/assets/cc843711-8e19-45aa-ba7d-a8bce2b52939)
