### PR TITLE
Fix issue with category names containing dots (.)

### DIFF
--- a/assets/js/categories.js
+++ b/assets/js/categories.js
@@ -1,7 +1,7 @@
 ---
 ---
 
-const categories = { {% for category in site.categories %}{% capture category_name %}{{ category | first }}{% endcapture %}{{ category_name | replace: " ", "_" }}: [{% for post in site.categories[category_name] %}{ url: `{{ site.baseurl }}{{ post.url }}`, date: `{{post.date | date_to_string}}`, title: `{{post.title}}`},{% endfor %}],{% endfor %} }
+const categories = { {% for category in site.categories %}{% capture category_name %}{{ category | first }}{% endcapture %}"{{ category_name | replace: " ", "_" }}": [{% for post in site.categories[category_name] %}{ url: `{{ site.baseurl }}{{ post.url }}`, date: `{{post.date | date_to_string}}`, title: `{{post.title}}`},{% endfor %}],{% endfor %} }
 
 console.log(categories);
 


### PR DESCRIPTION
Hi, I'm really enjoying your theme! 
I encountered an issue where the category modal wouldn't open when I named one of the categories **Node.js**
So I wrapped the category name in quotes in the Javascript file
It seems to work now, so I’d appreciate it if you could check this out

Thanks again for your awesome theme!